### PR TITLE
Fill product pages with content

### DIFF
--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,8 +1,19 @@
 export default function About() {
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">About Us</h1>
-      <p>StoryBookUI helps families create unique bedtime stories.</p>
+    <div className="max-w-3xl mx-auto space-y-4 text-gray-700">
+      <h1 className="text-3xl font-bold text-center mb-6">Quiénes Somos</h1>
+      <p>
+        Make a Tale es una plataforma que permite a padres, educadores y niños
+        generar cuentos infantiles personalizados al instante utilizando
+        inteligencia artificial. Nuestro objetivo es fomentar la creatividad y
+        el hábito de lectura ofreciendo una herramienta accesible y divertida
+        para toda la familia.
+      </p>
+      <p>
+        Inspirados por la idea de crear momentos mágicos antes de dormir,
+        combinamos tecnología y sencillez para que cualquiera pueda dar vida a
+        historias únicas desde su navegador y sin conocimientos técnicos.
+      </p>
     </div>
   );
 }

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -1,8 +1,30 @@
 export default function FAQ() {
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">FAQ</h1>
-      <p>More information will be available soon.</p>
+    <div className="max-w-3xl mx-auto">
+      <h1 className="text-3xl font-bold text-center mb-8">Preguntas Frecuentes</h1>
+      <div className="space-y-4">
+        <details className="bg-white rounded shadow p-4">
+          <summary className="font-medium cursor-pointer">¿Qué es Make a Tale?</summary>
+          <p className="mt-2 text-gray-700">
+            Es una aplicación web que genera cuentos infantiles personalizados a
+            partir de una breve descripción proporcionada por el usuario.
+          </p>
+        </details>
+        <details className="bg-white rounded shadow p-4">
+          <summary className="font-medium cursor-pointer">¿Necesito instalar algo?</summary>
+          <p className="mt-2 text-gray-700">No, la plataforma funciona directamente desde tu navegador.</p>
+        </details>
+        <details className="bg-white rounded shadow p-4">
+          <summary className="font-medium cursor-pointer">¿Cuánto cuesta el servicio?</summary>
+          <p className="mt-2 text-gray-700">
+            Puedes probarlo gratis con un cuento. Luego puedes adquirir 10 cuentos por 10&nbsp;USD en el plan Pay as You Go.
+          </p>
+        </details>
+        <details className="bg-white rounded shadow p-4">
+          <summary className="font-medium cursor-pointer">¿Puedo cancelar en cualquier momento?</summary>
+          <p className="mt-2 text-gray-700">Sí, no existen contratos ni compromisos a largo plazo.</p>
+        </details>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/MakeATale.tsx
+++ b/frontend/src/pages/MakeATale.tsx
@@ -25,22 +25,35 @@ export default function MakeATale() {
   const disabled = loading || description.trim() === '';
 
   return (
-    <div className="max-w-xl mx-auto space-y-4">
-      <textarea
-        className="w-full border rounded p-2"
-        rows={3}
-        placeholder="Describe your tale..."
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-      />
-      <button
-        onClick={handleGenerate}
-        disabled={disabled}
-        className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
-      >
-        {loading ? 'Generating...' : 'Generate'}
-      </button>
-      {tale && <pre className="whitespace-pre-wrap border p-2">{tale}</pre>}
+    <div className="max-w-2xl mx-auto space-y-4">
+      <h1 className="text-3xl font-bold text-center mb-2">Crea tu Cuento</h1>
+      <p className="text-center text-gray-600">
+        Describe la historia que te gustaría contar y deja que la magia comience.
+      </p>
+      <div className="bg-white p-4 sm:p-6 rounded shadow space-y-4">
+        <textarea
+          className="w-full border rounded p-2 focus:outline-none focus:ring"
+          rows={3}
+          placeholder="Un dragón aventurero en el espacio..."
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <button
+          onClick={handleGenerate}
+          disabled={disabled}
+          className="w-full py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+        >
+          {loading ? 'Generando...' : 'Generar cuento'}
+        </button>
+        {tale && (
+          <pre className="whitespace-pre-wrap border p-2 bg-gray-50 rounded max-h-96 overflow-y-auto">
+            {tale}
+          </pre>
+        )}
+      </div>
+      <p className="text-xs text-gray-500 text-center">
+        El servicio puede tardar unos segundos en responder.
+      </p>
     </div>
   );
 }

--- a/frontend/src/pages/Pricing.tsx
+++ b/frontend/src/pages/Pricing.tsx
@@ -1,8 +1,19 @@
 export default function Pricing() {
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">Pricing</h1>
-      <p>Start for free with 10 credits. More plans coming soon.</p>
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold text-center mb-8">Planes y Precios</h1>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="border rounded-lg p-6 flex flex-col items-center bg-white shadow">
+          <h2 className="text-xl font-semibold mb-2">Plan Gratuito</h2>
+          <p className="mb-4 text-gray-600 text-center">Genera un cuento de prueba para conocer la plataforma.</p>
+          <span className="text-3xl font-bold mb-4">$0</span>
+        </div>
+        <div className="border rounded-lg p-6 flex flex-col items-center bg-white shadow">
+          <h2 className="text-xl font-semibold mb-2">Pay as You Go</h2>
+          <p className="mb-4 text-gray-600 text-center">10 cuentos por tan solo 10&nbsp;USD.</p>
+          <span className="text-3xl font-bold mb-4">$10</span>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- flesh out About page with mission statement
- style Make a Tale form with headings and instructions
- add pricing cards for free and pay-as-you-go plans
- build FAQ section with expandable answers
- ensure build completes

## Testing
- `npm install --silent`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_6877a1b792a0832cbfadd1392a217fdc