### PR TITLE
Use Next.js in docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ OPENAI_API_KEY=sk-xxxx
 GROQ_API_KEY=groq-xxxx
 NEXT_PUBLIC_SUPABASE_URL=https://xyz.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-key
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ OPENAI_API_KEY=<your-openai-key>
 GROQ_API_KEY=<your-groq-key>
 NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+NEXT_PUBLIC_API_URL=http://localhost:8000
 ```
 
 ## Project Structure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,16 @@
 version: '3'
 services:
   frontend:
-    build: ./frontend
+    build:
+      context: ./nextapp
+      args:
+        NEXT_PUBLIC_API_URL: http://api:8000
+    environment:
+      - NEXT_PUBLIC_API_URL=http://api:8000
     ports:
       - '3000:3000'
+    depends_on:
+      - api
   api:
     build: ./api
     ports:

--- a/nextapp/Dockerfile
+++ b/nextapp/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:18-alpine AS build
+WORKDIR /app
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/nextapp/app/make/page.tsx
+++ b/nextapp/app/make/page.tsx
@@ -13,7 +13,7 @@ export default function MakeATale() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const apiUrl = 'http://makeataleapi-tvda3i.internal:8000';
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
   async function handleGenerate() {
     setLoading(true);


### PR DESCRIPTION
## Summary
- add Dockerfile to build the Next.js app
- configure docker-compose to use Next.js instead of the old frontend
- expose an `NEXT_PUBLIC_API_URL` variable and use it in the Next.js app
- document the new variable in `.env.example` and README

## Testing
- `npm install` && `npm run build` in `nextapp`

------
https://chatgpt.com/codex/tasks/task_e_687e32d0f9e8832ca1c770d15fb8ed13