### PR TITLE
feat: secure story generation using Supabase JWT credits

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11-slim
 WORKDIR /app
-RUN pip install --upgrade fastapi uvicorn langchain openai langchain_community langchain-groq
+RUN pip install --upgrade fastapi uvicorn langchain openai langchain_community langchain-groq supabase PyJWT
 COPY main.py .
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/main.py
+++ b/api/main.py
@@ -1,11 +1,15 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Header
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
 from langchain_groq import ChatGroq
 from langchain.schema import SystemMessage, HumanMessage
+from supabase import create_client, Client
+import jwt
 import os
 import re
 import json
+import asyncio
+from datetime import datetime, timezone, timedelta
 
 app = FastAPI()
 app.add_middleware(
@@ -14,6 +18,14 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Configuración de Supabase y JWT
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_JWT_SECRET = os.getenv("SUPABASE_JWT_SECRET")
+supabase: Client | None = None
+if SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY:
+    supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
 class TaleRequest(BaseModel):
     description: str
@@ -62,3 +74,124 @@ async def generate_story_ai(req: TaleAIRequest):
     if not story_json:
         return {"error": "No se pudo extraer el JSON", "raw": response.content}
     return story_json
+
+
+def verify_jwt(token: str) -> str:
+    if not SUPABASE_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="SUPABASE_JWT_SECRET not set")
+    try:
+        payload = jwt.decode(token, SUPABASE_JWT_SECRET, algorithms=["HS256"])
+        return payload.get("sub")
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expirado")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Token inválido")
+
+
+@app.post("/generate-story-ai-jwt")
+async def generate_story_ai_jwt(
+    req: TaleAIRequest, authorization: str | None = Header(default=None)
+):
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Falta token de autenticación")
+    token = authorization.split(" ", 1)[1]
+    user_id = verify_jwt(token)
+
+    if supabase is None:
+        raise HTTPException(status_code=500, detail="Supabase no configurado")
+
+    user_resp = (
+        supabase.table("profiles")
+        .select("credits, plan")
+        .eq("id", user_id)
+        .execute()
+    )
+    data = user_resp.data[0] if user_resp.data else {}
+    credits = data.get("credits", 0)
+    if credits <= 0:
+        raise HTTPException(
+            status_code=402,
+            detail="No tienes créditos disponibles. Suscríbete para continuar.",
+        )
+
+    groq_api_key = os.getenv("GROQ_API_KEY")
+    if not groq_api_key:
+        raise HTTPException(status_code=500, detail="GROQ_API_KEY not set")
+
+    chat = ChatGroq(
+        groq_api_key=groq_api_key,
+        model="llama-3.3-70b-versatile",
+        temperature=0.7,
+    )
+
+    system_prompt = (
+        "Eres un experto escritor de cuentos infantiles. "
+        "Escribe un cuento original dividido en capítulos, "
+        "cada capítulo debe tener un título y un texto breve. "
+        "Devuelve SOLO la respuesta en formato JSON con la estructura: "
+        "{\"chapters\": [{\"title\": \"...\", \"text\": \"...\"}, ...]}"
+    )
+
+    messages = [
+        SystemMessage(content=system_prompt),
+        HumanMessage(content=req.prompt),
+    ]
+    response = chat(messages)
+
+    def extract_json(text):
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group())
+            except Exception:
+                return None
+        return None
+
+    story_json = extract_json(response.content)
+    if not story_json:
+        raise HTTPException(status_code=500, detail="No se pudo extraer el JSON")
+
+    supabase.table("profiles").update({"credits": credits - 1}).eq("id", user_id).execute()
+    title = (
+        story_json.get("chapters", [{}])[0].get("title")
+        if story_json.get("chapters")
+        else "Story"
+    )
+    supabase.table("stories").insert(
+        {
+            "user_id": user_id,
+            "title": title,
+            "content": json.dumps(story_json),
+            "prompt": req.prompt,
+        }
+    ).execute()
+    return story_json
+
+
+async def refill_plus_credits():
+    while True:
+        if supabase is not None:
+            now = datetime.now(timezone.utc)
+            resp = (
+                supabase.table("profiles")
+                .select("id, credits, plan, plus_since, last_credited_at")
+                .eq("plan", "plus")
+                .execute()
+            )
+            for user in resp.data or []:
+                last = user.get("last_credited_at") or user.get("plus_since")
+                if last:
+                    last_dt = datetime.fromisoformat(str(last).replace("Z", "+00:00"))
+                else:
+                    last_dt = now
+                if now - last_dt >= timedelta(days=30):
+                    new_credits = (user.get("credits") or 0) + 10
+                    supabase.table("profiles").update(
+                        {"credits": new_credits, "last_credited_at": now.isoformat()}
+                    ).eq("id", user["id"]).execute()
+        await asyncio.sleep(60 * 60 * 24)
+
+
+@app.on_event("startup")
+async def startup_event():
+    asyncio.create_task(refill_plus_credits())

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,5 +1,104 @@
-CREATE TABLE IF NOT EXISTS user_credits (
-  id uuid PRIMARY KEY REFERENCES auth.users(id),
-  credits integer NOT NULL DEFAULT 0,
-  created_at timestamptz DEFAULT now()
+-- Create stories table for storing user-generated tales
+CREATE TABLE IF NOT EXISTS stories (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  prompt TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+-- Create index for faster queries by user_id
+CREATE INDEX IF NOT EXISTS idx_stories_user_id ON stories(user_id);
+
+-- Create index for ordering by created_at
+CREATE INDEX IF NOT EXISTS idx_stories_created_at ON stories(created_at DESC);
+
+-- Enable Row Level Security (RLS)
+ALTER TABLE stories ENABLE ROW LEVEL SECURITY;
+
+-- Create policy to allow users to see only their own stories
+CREATE POLICY "Users can view their own stories" ON stories
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- Create policy to allow users to insert their own stories
+CREATE POLICY "Users can insert their own stories" ON stories
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+-- Create policy to allow users to update their own stories
+CREATE POLICY "Users can update their own stories" ON stories
+  FOR UPDATE USING (auth.uid() = user_id);
+
+-- Create policy to allow users to delete their own stories
+CREATE POLICY "Users can delete their own stories" ON stories
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Create function to automatically update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- Create trigger to automatically update updated_at
+CREATE TRIGGER update_stories_updated_at
+  BEFORE UPDATE ON stories
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+
+-- Create profiles table for storing user-specific data like credits and plan
+CREATE TABLE IF NOT EXISTS profiles (
+  id UUID REFERENCES auth.users(id) ON DELETE CASCADE PRIMARY KEY,
+  credits INTEGER NOT NULL DEFAULT 10,
+  plan TEXT NOT NULL DEFAULT 'free', -- 'free' or 'plus'
+  plus_since TIMESTAMP WITH TIME ZONE, -- Date when user subscribed to 'plus' plan
+  last_credited_at TIMESTAMP WITH TIME ZONE, -- Last time credits were automatically added
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Create index for faster queries by id
+CREATE INDEX IF NOT EXISTS idx_profiles_id ON profiles(id);
+
+-- Enable Row Level Security (RLS)
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+-- Create policy to allow users to view their own profile
+CREATE POLICY "Users can view their own profile" ON profiles
+  FOR SELECT USING (auth.uid() = id);
+
+-- Create policy to allow users to insert their own profile (e.g., on signup)
+CREATE POLICY "Users can insert their own profile" ON profiles
+  FOR INSERT WITH CHECK (auth.uid() = id);
+
+-- Create policy to allow users to update their own profile (e.g., update credits/plan)
+CREATE POLICY "Users can update their own profile" ON profiles
+  FOR UPDATE USING (auth.uid() = id);
+
+-- Optional: Function to create a profile for new users automatically
+-- This function will be triggered when a new user signs up in auth.users
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.profiles (id, credits, plan, created_at)
+  VALUES (NEW.id, 10, 'free', NOW());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Drop existing trigger if it exists to avoid conflicts
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+-- Create trigger to call handle_new_user function on new user creation
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Set ownership for RLS to work correctly
+ALTER FUNCTION public.handle_new_user() OWNER TO postgres;
+ALTER TABLE public.profiles OWNER TO postgres;
+GRANT ALL ON TABLE public.profiles TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.handle_new_user() TO anon, authenticated, service_role;


### PR DESCRIPTION
## Summary
- add `/generate-story-ai-jwt` endpoint gated by Supabase JWT tokens
- deduct one credit per story, blocking when out of credits
- auto top-up 10 monthly credits for `plus` subscribers

## Testing
- `python -m py_compile api/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6890864c3300832c94c94e49b6c1590e