### PR TITLE
fix: add missing logging import

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ import re
 import json
 import asyncio
 from datetime import datetime, timezone, timedelta
+import logging
 
 app = FastAPI()
 app.add_middleware(


### PR DESCRIPTION
## Summary
- add missing logging import to main FastAPI app

## Testing
- `python -m py_compile api/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6890af54aa84832c8aad25eee139e642