### PR TITLE
Install logging library for Docker

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11-slim
 WORKDIR /app
-RUN pip install --upgrade fastapi uvicorn langchain openai langchain_community langchain-groq supabase PyJWT
+RUN pip install --upgrade fastapi uvicorn langchain openai langchain_community langchain-groq supabase PyJWT logging
 COPY main.py .
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- ensure logging package is installed in API Docker image

## Testing
- `python -m py_compile api/main.py`
- `docker build -t storybook-api-test ./api` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890b27038cc832c9a21c1e1aea8c01b